### PR TITLE
auto_ptr to unique_ptr

### DIFF
--- a/NtupleProducer/plugins/EleFiller.cc
+++ b/NtupleProducer/plugins/EleFiller.cc
@@ -179,7 +179,7 @@ EleFiller::EleFiller(const edm::ParameterSet& iConfig) :
 
 
   // Output collection
-  auto_ptr<pat::ElectronCollection> result( new pat::ElectronCollection() );
+  std::unique_ptr<pat::ElectronCollection> result = std::make_unique<pat::ElectronCollection>();
 
   //unsigned int i=0;
   //for (unsigned int i = 0; i< electronHandle->size(); ++i){
@@ -342,7 +342,7 @@ EleFiller::EleFiller(const edm::ParameterSet& iConfig) :
     result->push_back(l);
     //i++;
   }
-  iEvent.put(result);
+  iEvent.put( std::move(result) );
 }
 
 

--- a/NtupleProducer/plugins/GenFiller.cc
+++ b/NtupleProducer/plugins/GenFiller.cc
@@ -69,7 +69,7 @@ void GenFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     tauHadcandsMothers_.clear();
     
     // output collection
-    auto_ptr<pat::GenericParticleCollection> result( new pat::GenericParticleCollection );
+    std::unique_ptr<pat::GenericParticleCollection> result =  std::make_unique<pat::GenericParticleCollection>();
     
     unsigned int Ngen = genHandle->size();
 
@@ -292,7 +292,7 @@ void GenFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
         result->push_back (tauH);
 	result->push_back (tauH_neutral);
     }        
-    iEvent.put(result);
+    iEvent.put( std::move(result) );
 }
 
 // set of requirement(s) defining which particle must be saved

--- a/NtupleProducer/plugins/LeptonPhotonMatcher.cc
+++ b/NtupleProducer/plugins/LeptonPhotonMatcher.cc
@@ -93,8 +93,8 @@ LeptonPhotonMatcher::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
 
   // Output collections
-  auto_ptr<pat::MuonCollection> resultMu( new pat::MuonCollection() );
-  auto_ptr<pat::ElectronCollection> resultEle( new pat::ElectronCollection() );
+  std::unique_ptr<pat::MuonCollection>     resultMu  = std::make_unique<pat::MuonCollection>();
+  std::unique_ptr<pat::ElectronCollection> resultEle = std::make_unique<pat::ElectronCollection>();
 
   // Associate a vector of Ptr<Photon> to lepton pointers
   typedef map<const reco::Candidate*, PhotonPtrVector> PhotonLepMap;
@@ -217,8 +217,8 @@ LeptonPhotonMatcher::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   }
   
   //Put the result in the event
-  iEvent.put(resultMu,"muons");
-  iEvent.put(resultEle,"electrons");
+  iEvent.put(std::move(resultMu),"muons");
+  iEvent.put(std::move(resultEle),"electrons");
 }
 
 

--- a/NtupleProducer/plugins/MergeTauCollections.cc
+++ b/NtupleProducer/plugins/MergeTauCollections.cc
@@ -62,7 +62,7 @@ void MergeTauCollections::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   iEvent.getByToken(theCandidateTag, tauHandle);
 
   // Output collection
-  auto_ptr<pat::TauCollection> result( new pat::TauCollection() );
+  std::unique_ptr<pat::TauCollection> result = std::make_unique<pat::TauCollection>();
 
   edm::Handle<pat::TauCollection> tauHandleTauUp;
   iEvent.getByToken(theCandidateTagTauUp, tauHandleTauUp);
@@ -123,7 +123,7 @@ void MergeTauCollections::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     result->push_back(l_Nominal);
   }
 
-  iEvent.put(result);
+  iEvent.put( std::move(result) );
 
 }
  

--- a/NtupleProducer/plugins/MuFiller.cc
+++ b/NtupleProducer/plugins/MuFiller.cc
@@ -110,7 +110,7 @@ MuFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   //iEvent.getByLabel("offlineSlimmedPrimaryVertices",vertexs);
 
   // Output collection
-  auto_ptr<pat::MuonCollection> result( new pat::MuonCollection() );
+  std::unique_ptr<pat::MuonCollection> result = std::make_unique<pat::MuonCollection>();
 
   for (unsigned int i = 0; i< muonHandle->size(); ++i){
     //---Clone the pat::Muon
@@ -283,7 +283,7 @@ MuFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     
     result->push_back(l);
   }
-  iEvent.put(result);
+  iEvent.put( std::move(result) );
 }
 
 #include <FWCore/Framework/interface/MakerMacros.h>

--- a/NtupleProducer/plugins/PairUnpacker.cc
+++ b/NtupleProducer/plugins/PairUnpacker.cc
@@ -71,7 +71,7 @@ void PairUnpacker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    iEvent.getByLabel(_InputPairsTag, pairHandle);
    
    // output collection
-   auto_ptr<reco::CandidateCollection> result( new reco::CandidateCollection );
+   std::unique_ptr<reco::CandidateCollection> result = std::make_unique<reco::CandidateCollection>();
 
    // if pairIndex exceeds Pair collection size, do not do anything
    if (_pairIndex < pairHandle->size() )
@@ -88,7 +88,7 @@ void PairUnpacker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    }
    //else cout << "Unpacked nothing, returning" << endl;
 
-   iEvent.put(result);   
+   iEvent.put( std::move(result) );   
 }
 
 

--- a/NtupleProducer/plugins/SVfitByPass.cc
+++ b/NtupleProducer/plugins/SVfitByPass.cc
@@ -87,7 +87,7 @@ void SVfitBypass::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   unsigned int elNumber = pairHandle->size();
   
     // Output collection
-  auto_ptr<pat::CompositeCandidateCollection> result( new pat::CompositeCandidateCollection );
+  std::unique_ptr<pat::CompositeCandidateCollection> result = std::make_unique<pat::CompositeCandidateCollection>();
 
   // get event pat MET to be saved in output
   double METx = 0.;
@@ -173,7 +173,7 @@ void SVfitBypass::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
     result->push_back(pair);
   }
-  iEvent.put(result);
+  iEvent.put( std::move(result) );
 }
 
 #include <FWCore/Framework/interface/MakerMacros.h>

--- a/NtupleProducer/plugins/TauFiller.cc
+++ b/NtupleProducer/plugins/TauFiller.cc
@@ -183,7 +183,7 @@ TauFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   iEvent.getByToken(theVtxTag, vertexs);
 
   // Output collection
-  auto_ptr<pat::TauCollection> result( new pat::TauCollection() );
+  std::unique_ptr<pat::TauCollection> result = std::make_unique<pat::TauCollection>();
 
   for (unsigned int itau = 0; itau < tauHandle->size(); ++itau){
     //---Clone the pat::Tau
@@ -457,7 +457,7 @@ TauFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     
     result->push_back(l);
   }
-  iEvent.put(result);
+  iEvent.put( std::move(result) );
 }
 
 

--- a/NtupleProducer/plugins/ZrecoilCorrectionProducer.cc
+++ b/NtupleProducer/plugins/ZrecoilCorrectionProducer.cc
@@ -85,7 +85,7 @@ ZrecoilCorrectionProducer::~ZrecoilCorrectionProducer()
 
 void ZrecoilCorrectionProducer::produce(edm::Event& evt, const edm::EventSetup& es)
 {  
-  std::auto_ptr<pat::METCollection> result(new pat::METCollection());
+  std::unique_ptr<pat::METCollection> result = std::make_unique<pat::METCollection>();
 
   // retrieve gen info
   edm::Handle<reco::GenParticleCollection> genParticles;
@@ -193,7 +193,7 @@ void ZrecoilCorrectionProducer::produce(edm::Event& evt, const edm::EventSetup& 
     */
   }
 
-  evt.put(result);
+  evt.put( std::move(result) );
 }
 
 #include <FWCore/Framework/interface/MakerMacros.h>

--- a/NtupleProducer/plugins/bFiller.cc
+++ b/NtupleProducer/plugins/bFiller.cc
@@ -105,7 +105,7 @@ void bFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   iEvent.getByToken(theCandidateTag, genHandle);
 
   // Output collection
-  auto_ptr<pat::GenericParticleCollection> result( new pat::GenericParticleCollection() );
+  std::unique_ptr<pat::GenericParticleCollection> result = std::make_unique<pat::GenericParticleCollection>();
   //  printf("size %d\n",genHandle->size());
   //for(GenParticleCollection::const_iterator genp = genHandle->begin();genp != genHandle->end(); ++ genp ) {  // loop over GEN particles
   for (unsigned int i = 0; i< genHandle->size(); ++i){
@@ -183,7 +183,7 @@ void bFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     }
 
   }//end isb
-  iEvent.put(result);
+  iEvent.put( std::move(result) );
 }//end loop over genParticles
 
 // ------------ method called once each job just before starting event loop  ------------


### PR DESCRIPTION
Zmiany by skompilować LLRAnalysis w nowych CMSSW (9XY) z nowszym gcc, ogólnie zamiana typu smart pointerów. 

Powinno działać rownież z 80X, ale może zatagować (lub rozdzielić) branch Moriond17 przed mergowaniem - do decyzji @akalinow 

Żeby to działało na 9XY podobne poprawki trzeba wprowadzić również do pluginów w UFHZZAnalysisRun2 - mogę wsłać patch'a lub tar-ball'a lub możemy czekać że autorzy sami poprawią (klona nie chce mi się robić)
