### PR TITLE
Add DNN-based discriminants

### DIFF
--- a/NtupleProducer/plugins/TauFiller.cc
+++ b/NtupleProducer/plugins/TauFiller.cc
@@ -101,7 +101,15 @@ TauFiller::TauFiller(const edm::ParameterSet& iConfig) :
     "byTightIsolationMVArun2v1DBoldDMwLT2017v2",
     "byVTightIsolationMVArun2v1DBoldDMwLT2017v2",
     "byVVTightIsolationMVArun2v1DBoldDMwLT2017v2",
-    
+
+    "byVVLooseIsolationMVArun2v1DBnewDMwLT2017v2",
+    "byVLooseIsolationMVArun2v1DBnewDMwLT2017v2",
+    "byLooseIsolationMVArun2v1DBnewDMwLT2017v2",
+    "byMediumIsolationMVArun2v1DBnewDMwLT2017v2",
+    "byTightIsolationMVArun2v1DBnewDMwLT2017v2",
+    "byVTightIsolationMVArun2v1DBnewDMwLT2017v2",
+    "byVVTightIsolationMVArun2v1DBnewDMwLT2017v2",
+
     "againstMuonLoose3",
     "againstMuonTight3",
 
@@ -118,6 +126,7 @@ TauFiller::TauFiller(const edm::ParameterSet& iConfig) :
     "byCombinedIsolationDeltaBetaCorrRaw3Hits",
     "byIsolationMVArun2v1DBoldDMwLTraw",
     "byIsolationMVArun2v1DBoldDMwLTraw2017v2",
+    "byIsolationMVArun2v1DBnewDMwLTraw2017v2",
     "againstElectronMVA6Raw",
     "againstElectronMVA6category",
     "photonPtSumOutsideSignalCone",
@@ -126,6 +135,21 @@ TauFiller::TauFiller(const edm::ParameterSet& iConfig) :
     "chargedIsoPtSumdR03",
     "neutralIsoPtSumdR03",
     "puCorrPtSum",
+
+    "deepTau2017v1tauVSe",
+    "deepTau2017v1tauVSmu",
+    "deepTau2017v1tauVSjet",
+    "deepTau2017v1tauVSall",
+
+    "DPFTau_2016_v0tauVSe",
+    "DPFTau_2016_v0tauVSmu",
+    "DPFTau_2016_v0tauVSjet",
+    "DPFTau_2016_v0tauVSall",
+
+    "DPFTau_2016_v1tauVSe",
+    "DPFTau_2016_v1tauVSmu",
+    "DPFTau_2016_v1tauVSjet",
+    "DPFTau_2016_v1tauVSall",
   };
 
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ scram project -n CMSSW_9_4_8_ntuple CMSSW CMSSW_9_4_8
 cd CMSSW_9_4_8_ntuple/src
 cmsenv
 
+git cms-init
+git cms-merge-topic mbluj:CMSSW_9_4_X_DPFIso
+
 git clone https://github.com/SVfit/ClassicSVfit TauAnalysis/ClassicSVfit -b release_2018Mar20
 git clone https://github.com/SVfit/SVfitTF TauAnalysis/SVfitTF
 git clone https://github.com/akalinow/LLRHiggsTauTau.git


### PR DESCRIPTION
Dodajemy dyskryminatory bazujace na DNN (tylko raw, tj. bez WP)
* deepTau2017v1: tau vs e, tau vs mu, tau vs jet, tau vs all;
* DPFTau_2016_v0: tau vs e, tau vs mu, tau vs jet, tau vs all;
* DPFTau_2016_v1: tau vs e, tau vs mu, tau vs jet, tau vs all;

gdzie tau vs X=e,mu,jet oznacza trening na odroznianie tau od X, a tau vs all usrednienie po powyzszych. Dla DPF wszystkie wersje sa takie same i oznaczaja all (?). 

Zarowno deepTau jak DPF trenowane dla nowych decay modow (new DMs). Zwracane wartosci pomiędzy 0 a 1 z -1 jako blad na wejsciu. Dla deepTau i DPF v0 sygnal pikuje na 1 a dla DPF v1 na 0 (czyli nalezy uzywac DPFv1 = DPFv1>-1.? 1.-DPFv1 : -1. )

DPF trenowany dla tau po preselekcji pT>30, anit-e/mu VL/L i MVAIso (2015) VL - jak to nie jest spelnione zwraca -1. 

Dodatkowo dodano MVAIso2017v2 dla new DMs, bo wyglada na to, ze jest lepsze niz dla old DMs.

Instrukcja instalacyjna tez odswiezona.

Poprawki w Production wkrotce.