### PR TITLE
Poprawiona instrukcja

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ cmsenv
 git cms-init
 git cms-merge-topic mbluj:CMSSW_9_4_X_DPFIso
 
+mkdir -p $CMSSW_BASE/external/$SCRAM_ARCH/data
+cd $CMSSW_BASE/external/$SCRAM_ARCH/data
+git clone https://github.com/cms-tau-pog/RecoTauTag-TrainingFiles -b master RecoTauTag/TrainingFiles/data
+cd -
+ 
 git clone https://github.com/SVfit/ClassicSVfit TauAnalysis/ClassicSVfit -b release_2018Mar20
 git clone https://github.com/SVfit/SVfitTF TauAnalysis/SVfitTF
 git clone https://github.com/akalinow/LLRHiggsTauTau.git


### PR DESCRIPTION
Instrukcja instalacji zostala poprawiona ze wzgledu na przeniesienie plikow z treningami do osobnego repozytorium (*). Pliki te sa kopiowane w miejsce, ktore powinno byc "niewidoczne" dla Craba, wiec nie powinny zapychac sandboxa. Krok ze sciaganiem danych musi byc powtorzony przez job Crabowy tj. musi byc dodany do odpowiedniego skryptu. Odpowiednia modyfikacja `Production` w drodze.

(*) Jesli juz instalowales to powtorz od zera bo branch `mbluj/CMSSW_9_4_X_DPFIso` zostala zmodyfikowana.