### PR TITLE
Kolejny update instrukcji

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,6 @@ cmsenv
 
 git cms-init
 git cms-merge-topic mbluj:CMSSW_9_4_X_DPFIso
-
-mkdir -p $CMSSW_BASE/external/$SCRAM_ARCH/data
-cd $CMSSW_BASE/external/$SCRAM_ARCH/data
-git clone https://github.com/cms-tau-pog/RecoTauTag-TrainingFiles -b master RecoTauTag/TrainingFiles/data
-cd -
  
 git clone https://github.com/SVfit/ClassicSVfit TauAnalysis/ClassicSVfit -b release_2018Mar20
 git clone https://github.com/SVfit/SVfitTF TauAnalysis/SVfitTF
@@ -19,6 +14,12 @@ git clone https://github.com/CMS-HTT/RecoilCorrections.git  HTT-utilities/Recoil
 cd LLRHiggsTauTau; git checkout Run2017; cd -
 
 scram b -j 4
+
+# Clone DNN datafiles to cmssw externals (it must be done after 1st compilation)
+mkdir -p $CMSSW_BASE/external/$SCRAM_ARCH/data
+cd $CMSSW_BASE/external/$SCRAM_ARCH/data
+git clone https://github.com/cms-tau-pog/RecoTauTag-TrainingFiles -b master RecoTauTag/TrainingFiles/data
+cd -
 
 cd LLRHiggsTauTau/NtupleProducer/test/
 git clone https://github.com/akalinow/Production.git


### PR DESCRIPTION
Okazuje sie ze zmiany w external musza byc robione po 1-wszej kompilacji, bo inaczej sa czyszczone => odpowiednie zmiany w kolejnosci instalacji.